### PR TITLE
ci(npm): add `registry-url`

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -33,6 +33,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18
+          registry-url: 'registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}'
           cache: 'pnpm'
 
       - name: Get Latest Tag

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
-//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}
 save-workspace-protocol=false


### PR DESCRIPTION
Moved `registry-url` from `.npmrc` to `npm` workflow