### PR TITLE
fix(sanity-plugin-getyourguide): lint errors

### DIFF
--- a/examples/sanity-plugin-getyourguide/.eslintrc
+++ b/examples/sanity-plugin-getyourguide/.eslintrc
@@ -1,3 +1,4 @@
 {
+  "root": true,
   "extends": "@sanity/eslint-config-studio"
 }

--- a/packages/sanity-plugin-getyourguide/lib/components/Form.tsx
+++ b/packages/sanity-plugin-getyourguide/lib/components/Form.tsx
@@ -13,6 +13,7 @@ type FormValue = React.JSX.IntrinsicElements["gyg-wc"] & {
 
 export function GetYourGuideForm(props: InputProps) {
   const [view, setView] = useState<"content" | "preview">("content");
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { _type, title, ...widgetAttrs } = (useFormValue(props.path) ?? {}) as FormValue;
   const { partnerId = 0, lang } = props.schemaType.options ?? {};
 

--- a/packages/sanity-plugin-getyourguide/lib/schemas/search/index.tsx
+++ b/packages/sanity-plugin-getyourguide/lib/schemas/search/index.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { defineType } from "sanity";
 import { GetYourGuideForm } from "../../components/Form";
 import { parseUrl } from "gyg-wc/utils";

--- a/packages/sanity-plugin-getyourguide/lib/schemas/tours/index.tsx
+++ b/packages/sanity-plugin-getyourguide/lib/schemas/tours/index.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { defineType } from "sanity";
 import { parseUrl } from "gyg-wc/utils";
 import { GetYourGuideForm } from "../../components/Form";


### PR DESCRIPTION
- Remove unused `React` import
- Disable `no-unused-vars` error